### PR TITLE
Run Playwright in a separate step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  Fast:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +29,27 @@ jobs:
 
       - run: npm run test:unit
 
+      - run: npm run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build
+
+  Slow:
+    runs-on: ubuntu-latest
+    needs: [Fast]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+
+      - run: npm install
+
       - run: npx playwright install --with-deps
 
       - run: npm run test:integration
@@ -39,16 +60,9 @@ jobs:
           name: playwright-report
           path: playwright-report
 
-      - run: npm run build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: build
-          path: build
-
-  publish:
+  Publish:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [Fast]
     if: ${{ !cancelled() && github.ref == 'refs/heads/trunk' }}
 
     permissions:
@@ -59,6 +73,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build
+          path: build
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Playwright is slow to install, so get it out of the critical path for publishing.

It's gated behind the fast lint and unit tests.
