### PR TITLE
Fix deploy path?

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,7 +15,12 @@ const config = {
             precompress: false,
             strict: true,
         }),
+        paths: {
+            base: "/halo",
+        },
     },
+
+    bundleStrategy: "inline",
 }
 
 export default config


### PR DESCRIPTION
The URL generated by Vite for the `?url` query were absolute paths like `/_app/...` which didn't work on GitHub Pages, where the app is deployed under `/halo`. Hopefully this aligns everything.
